### PR TITLE
Modify header links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:14
+        image: postgres:16
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready
@@ -33,7 +33,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
       redis:
-        image: redis:3.2-alpine
+        image: redis:7.2-alpine
         ports: ["6379:6379"]
 
     steps:

--- a/app/overrides/layouts/decidim/header/_main_links_desktop/navigation.html.erb.deface
+++ b/app/overrides/layouts/decidim/header/_main_links_desktop/navigation.html.erb.deface
@@ -1,0 +1,12 @@
+<!-- replace_contents '.main-bar__links-desktop__item-wrapper' -->
+
+<div>
+  <%= link_to decidim_participatory_processes.participatory_processes_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.pages.home.extended.participatory_processes") do %>
+    <%= icon "treasure-map-line" %><span><%= t("decidim.pages.home.extended.participatory_processes") %></span>
+  <% end %>
+</div>
+<div>
+  <%= link_to decidim_assemblies.assemblies_path, class: "main-bar__links-desktop__item", "aria-label": t("decidim.pages.home.extended.assemblies") do %>
+    <%= icon "government-line" %><span><%= t("decidim.pages.home.extended.assemblies") %></span>
+    <% end %>
+</div>

--- a/config/locales/missing.yml
+++ b/config/locales/missing.yml
@@ -5,6 +5,11 @@ ca:
       front_page_link: Ves a la pàgina principal
       logo: "Logo oficial de %{organization}"
       skip_button: Salta i ves al contingut principal
+    pages:
+      home:
+        extended:
+          participatory_processes: Participa
+          assemblies: Decideix
 es:
   decidim:
     accessibility:

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -9,7 +9,8 @@ checksums = [
   {
     package: "decidim-core",
     files: {
-      "/app/views/layouts/decidim/header/_main.html.erb" => "69acfdeade5dab8cd73e1d19f37fef2c"
+      "/app/views/layouts/decidim/header/_main.html.erb" => "69acfdeade5dab8cd73e1d19f37fef2c",
+      "/app/views/layouts/decidim/header/_main_links_desktop.html.erb" => "804ca6543a5a9ce94007da5964c0c965"
     }
   }
 ]


### PR DESCRIPTION
We are changing the main headers on the desktop version to suit better the needs of the organization.

before:
<img width="1095" height="218" alt="image" src="https://github.com/user-attachments/assets/404efc60-40d7-4788-b587-84d4bb2f4e9e" />

after:
<img width="1124" height="314" alt="image" src="https://github.com/user-attachments/assets/31f2897f-4258-4046-a73d-1711575fc96f" />
